### PR TITLE
Fix tool param and memory selection

### DIFF
--- a/app.py
+++ b/app.py
@@ -139,7 +139,7 @@ def multi_agent_query(query):
             insights_prompt = generate_insights_prompt(query, query_type)
             insights_response = insights_executor.invoke(
                 {
-                    "chat_history": st.session_state.sentiment_memory.load_memory_variables(
+                    "chat_history": st.session_state.insights_memory.load_memory_variables(
                         {}
                     )[
                         "chat_history"

--- a/tools.py
+++ b/tools.py
@@ -232,10 +232,11 @@ def get_news_from_newsapi(query: str) -> str:
 
 
 @tool("get_stock_analysis_tool", return_direct=False)
-def get_stock_analysis(query: str) -> str:
-    """
-    Fetches stock financial data, technical indicators, and news sentiment analysis
-    for a given stock symbol and provides a Buy/Hold/Sell recommendation.
+def get_stock_analysis(symbol: str) -> str:
+    """Return a brief buy/hold/sell analysis for ``symbol``.
+
+    Args:
+        symbol: Stock ticker symbol.
     """
 
     try:


### PR DESCRIPTION
## Summary
- use the insights agent memory when invoking the insights tool
- rename `get_stock_analysis` parameter to `symbol` and document it

## Testing
- `python -m py_compile tools.py app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863f8d84280832b844a7a7a3510f277