### PR TITLE
Fix run command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Or use a `.env` file with `python-dotenv`.
 ## ▶️ How to Run
 
 ```bash
-python -m streamlit run Stock.py
+python -m streamlit run app.py
 ```
 
 This will launch a browser window with a chatbot interface for asking financial questions.


### PR DESCRIPTION
## Summary
- update README to run `app.py` instead of `Stock.py`

## Testing
- `grep -R "Stock.py" -n --exclude-dir=.git`


------
https://chatgpt.com/codex/tasks/task_e_6863f9dcc55c832b87f5f0a95fafa945